### PR TITLE
Document building dependencies via cura-build-environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains build scripts used to build Cura and all dependencies from scratch.
 
+The build has a number of dependencies. Ideally, these dependencies should be installed by the [cura-build-environment](https://github.com/Ultimaker/cura-build-environment) repository. Even with cura-build-environment though, some things may still be missing from your system that we haven't thought of.
+
 ## OS X
 
 1. Install CMake (available via [homebrew](http://brew.sh/) or [cmake.org](http://www.cmake.org/))


### PR DESCRIPTION
So that more people may find it.

Fixes #182.